### PR TITLE
Build unit tests using Unity instead of CMock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/unit-test/Unity"]
+	path = test/unit-test/Unity
+	url = https://github.com/ThrowTheSwitch/Unity

--- a/jobsFilePaths.cmake
+++ b/jobsFilePaths.cmake
@@ -1,0 +1,14 @@
+# This file is to add source files and include directories
+# into variables so that it can be reused from different repositories
+# in their Cmake based build system by including this file.
+#
+# Files specific to the repository such as test runner, platform tests
+# are not added to the variables.
+
+# AWS IoT Jobs library source files.
+set( JOBS_SOURCES
+     ${CMAKE_CURRENT_LIST_DIR}/source/jobs.c )
+
+# AWS IoT Jobs library Public Include directories.
+set( JOBS_INCLUDE_PUBLIC_DIRS
+     ${CMAKE_CURRENT_LIST_DIR}/source/include )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required( VERSION 3.13.0 )
+project( "Jobs unit test"
+         VERSION 1.0.0
+         LANGUAGES C )
+
+# Allow the project to be organized into folders.
+set_property( GLOBAL PROPERTY USE_FOLDERS ON )
+
+# Use C90.
+set( CMAKE_C_STANDARD 90 )
+set( CMAKE_C_STANDARD_REQUIRED ON )
+
+# Do not allow in-source build.
+if( ${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR} )
+    message( FATAL_ERROR "In-source build is not allowed. Please build in a separate directory, such as ${PROJECT_SOURCE_DIR}/build." )
+endif()
+
+# Set global path variables.
+get_filename_component(__MODULE_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+set( MODULE_ROOT_DIR ${__MODULE_ROOT_DIR} CACHE INTERNAL "AWS IoT Jobs source root." )
+set( UNIT_TEST_DIR ${MODULE_ROOT_DIR}/test/unit-test CACHE INTERNAL "AWS IoT Jobs unit test directory." )
+set( UNITY_DIR ${UNIT_TEST_DIR}/Unity CACHE INTERNAL "Unity library source directory." )
+
+# Configure options to always show in CMake GUI.
+option( BUILD_CLONE_SUBMODULES
+        "Set this to ON to automatically clone any required Git submodules. When OFF, submodules must be manually cloned."
+        ON )
+
+# Set output directories.
+set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
+
+# ================================ Coverity Analysis Configuration =================================
+
+# Include filepaths for source and include.
+include( ${MODULE_ROOT_DIR}/jobsFilePaths.cmake )
+# Target for Coverity analysis that builds the library.
+add_library( coverity_analysis
+             ${JOBS_SOURCES} )
+# AWS IoT Jobs public include path.
+target_include_directories( coverity_analysis PUBLIC ${JOBS_INCLUDE_PUBLIC_DIRS} )
+
+#  ====================================  Test Configuration ========================================
+
+# Include Unity build configuration.
+include( unit-test/unity_build.cmake )
+
+# Check if the Unity source directory exists, and if not present, clone the submodule
+# if BUILD_CLONE_SUBMODULES configuration is enabled.
+if( NOT EXISTS ${UNITY_DIR}/src )
+    # Attempt to clone Unity.
+    if( ${BUILD_CLONE_SUBMODULES} )
+        clone_unity()
+    else()
+        message( FATAL_ERROR "The required submodule Unity does not exist. Either clone it manually, or set BUILD_CLONE_SUBMODULES to 1 to automatically clone it during build." )
+    endif()
+endif()
+
+# Add unit test and coverage configuration.
+
+# Use CTest utility for managing test runs. This has to be added BEFORE
+# defining test targets with add_test()
+enable_testing()
+
+# Add build targets for Unity and Unit, required for unit testing.
+add_unity_targets()
+
+# Add function to enable Unity based tests and coverage.
+include( ${MODULE_ROOT_DIR}/tools/unity/create_test.cmake )
+
+# Include build configuration for unit tests.
+add_subdirectory( unit-test )
+
+#  ==================================== Coverage Analysis configuration ============================
+
+# Add a target for running coverage on tests.
+add_custom_target( coverage
+    COMMAND ${CMAKE_COMMAND} -DUNITY_DIR=${UNITY_DIR}
+    -P ${MODULE_ROOT_DIR}/tools/unity/coverage.cmake
+    DEPENDS unity jobs_utest
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+)

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -1,0 +1,49 @@
+include( ${MODULE_ROOT_DIR}/jobsFilePaths.cmake )
+
+# ====================  Define your project name (edit) ========================
+set(project_name "jobs")
+
+# =====================  Create your mock here  (edit)  ========================
+# ================= Create the library under test here (edit) ==================
+
+# list the files you would like to test here
+list(APPEND real_source_files
+            ${JOBS_SOURCES}
+        )
+# list the directories the module under test includes
+list(APPEND real_include_directories
+            ${JOBS_INCLUDE_PUBLIC_DIRS}
+        )
+
+# =====================  Create UnitTest Code here (edit)  =====================
+
+# list the directories your test needs to include
+list(APPEND test_include_directories
+            ${JOBS_INCLUDE_PUBLIC_DIRS}
+        )
+
+# =============================  (end edit)  ===================================
+
+set(real_name "${project_name}_real")
+
+create_real_library(${real_name}
+                    "${real_source_files}"
+                    "${real_include_directories}"
+        )
+
+list(APPEND utest_link_list
+            lib${real_name}.a
+        )
+
+list(APPEND utest_dep_list
+            ${real_name}
+        )
+
+set(utest_name "${project_name}_utest")
+set(utest_source "${project_name}_utest.c")
+create_test(${utest_name}
+            ${utest_source}
+            "${utest_link_list}"
+            "${utest_dep_list}"
+            "${test_include_directories}"
+        )

--- a/test/unit-test/jobs_utest.c
+++ b/test/unit-test/jobs_utest.c
@@ -1,0 +1,44 @@
+/*
+ * AWS IoT Jobs v1.0.0
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @file jobs_utest.c
+ * @brief Unit tests for the AWS IoT Jobs library.
+ */
+
+#include "unity.h"
+
+/* Include paths for public enums, structures, and macros. */
+#include "jobs.h"
+
+/**
+ * @brief Test that Jobs_MatchTopic is able to classify any null or bad parameters.
+ */
+void test_Jobs_MatchTopic_Invalid_Params( void )
+{
+    JobsStatus_t jobsStatus;
+    char * outJobId;
+    uint16_t outJobIdLength;
+
+    jobsStatus = Jobs_MatchTopic( NULL, 0, NULL, 0, NULL, &outJobId, &outJobIdLength );
+    TEST_ASSERT_EQUAL( JobsBadParameter, jobsStatus );
+}

--- a/test/unit-test/unity_build.cmake
+++ b/test/unit-test/unity_build.cmake
@@ -1,0 +1,38 @@
+# Macro utility to clone the Unity submodule.
+macro( clone_unity )
+        find_package( Git REQUIRED )
+        message( "Cloning submodule Unity." )
+        execute_process( COMMAND rm -rf ${UNITY_DIR}
+                         COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive ${UNITY_DIR}
+                        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                        RESULT_VARIABLE UNITY_CLONE_RESULT )
+
+        if( NOT ${UNITY_CLONE_RESULT} STREQUAL "0" )
+                message( FATAL_ERROR "Failed to clone Unity submodule." )
+        endif()
+endmacro()
+
+# Macro utility to add library targets for Unity and Unity to build configuration.
+macro( add_unity_targets )
+        # Build Configuration for Unity and Unity libraries.
+        list( APPEND UNITY_INCLUDE_DIRS
+                "${UNITY_DIR}/src/"
+                "${UNITY_DIR}/extras/fixture/src"
+                "${UNITY_DIR}/extras/memory/src"
+        )
+
+        add_library( unity STATIC
+                "${UNITY_DIR}/src/unity.c"
+                "${UNITY_DIR}/extras/fixture/src/unity_fixture.c"
+                "${UNITY_DIR}/extras/memory/src/unity_memory.c"
+        )
+
+        set_target_properties( unity PROPERTIES
+                ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
+                POSITION_INDEPENDENT_CODE ON
+        )
+
+        target_include_directories( unity PUBLIC
+                ${UNITY_INCLUDE_DIRS}
+        )
+endmacro()

--- a/tools/unity/coverage.cmake
+++ b/tools/unity/coverage.cmake
@@ -1,0 +1,70 @@
+# Taken from amazon-freertos repository
+cmake_minimum_required(VERSION 3.13)
+set(BINARY_DIR ${CMAKE_BINARY_DIR})
+# reset coverage counters
+execute_process(
+            COMMAND lcov --directory ${CMAKE_BINARY_DIR}
+                         --base-directory ${CMAKE_BINARY_DIR}
+                         --zerocounters
+
+            COMMAND mkdir -p  ${CMAKE_BINARY_DIR}/coverage
+        )
+# make the initial/baseline capture a zeroed out files
+execute_process( COMMAND lcov --directory ${CMAKE_BINARY_DIR}
+                         --base-directory ${CMAKE_BINARY_DIR}
+                         --initial
+                         --capture
+                         --rc lcov_branch_coverage=1
+                         --rc genhtml_branch_coverage=1
+                         --output-file=${CMAKE_BINARY_DIR}/base_coverage.info
+        )
+file(GLOB files "${CMAKE_BINARY_DIR}/bin/tests/*")
+
+set(REPORT_FILE ${CMAKE_BINARY_DIR}/utest_report.txt)
+file(WRITE ${REPORT_FILE} "")
+# execute all files in bin directory, gathering the output to show it in CI
+foreach(testname ${files})
+    get_filename_component(test
+                           ${testname}
+                           NAME_WLE
+            )
+    message("Running ${testname}")
+    execute_process(COMMAND ${testname} OUTPUT_FILE ${CMAKE_BINARY_DIR}/${test}_out.txt)
+
+    file(READ ${CMAKE_BINARY_DIR}/${test}_out.txt CONTENTS)
+    file(APPEND ${REPORT_FILE} "${CONTENTS}")
+endforeach()
+
+# generate Junit style xml output
+execute_process(COMMAND ruby
+    ${UNITY_DIR}/auto/parse_output.rb
+                    -xml ${REPORT_FILE}
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+
+# capture data after running the tests
+execute_process(
+            COMMAND lcov --capture
+                         --rc lcov_branch_coverage=1
+                         --rc genhtml_branch_coverage=1
+                         --base-directory ${CMAKE_BINARY_DIR}
+                         --directory ${CMAKE_BINARY_DIR}
+                         --output-file ${CMAKE_BINARY_DIR}/second_coverage.info
+        )
+
+# combile baseline results (zeros) with the one after running the tests
+execute_process(
+            COMMAND lcov --base-directory ${CMAKE_BINARY_DIR}
+                         --directory ${CMAKE_BINARY_DIR}
+                         --add-tracefile ${CMAKE_BINARY_DIR}/base_coverage.info
+                         --add-tracefile ${CMAKE_BINARY_DIR}/second_coverage.info
+                         --output-file ${CMAKE_BINARY_DIR}/coverage.info
+                         --no-external
+                         --rc lcov_branch_coverage=1
+        )
+execute_process(
+            COMMAND genhtml --rc lcov_branch_coverage=1
+                            --branch-coverage
+                            --output-directory ${CMAKE_BINARY_DIR}/coverage
+                                ${CMAKE_BINARY_DIR}/coverage.info
+        )

--- a/tools/unity/create_test.cmake
+++ b/tools/unity/create_test.cmake
@@ -1,0 +1,73 @@
+# Taken from amazon-freertos repository
+
+#function to create the test executable
+function(create_test test_name
+                     test_src
+                     link_list
+                     dep_list
+                     include_list)
+    include (CTest)
+    get_filename_component(test_src_absolute ${test_src} ABSOLUTE)
+    add_custom_command(OUTPUT ${test_name}_runner.c
+                  COMMAND ruby
+                    ${UNITY_DIR}/auto/generate_test_runner.rb
+                    ${MODULE_ROOT_DIR}/tools/unity/project.yml
+                    ${test_src_absolute}
+                    ${test_name}_runner.c
+                  DEPENDS ${test_src}
+        )
+    add_executable(${test_name} ${test_src} ${test_name}_runner.c)
+    set_target_properties(${test_name} PROPERTIES
+            COMPILE_FLAG "-O0 -ggdb"
+            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/tests"
+            INSTALL_RPATH_USE_LINK_PATH TRUE
+            LINK_FLAGS " \
+                -Wl,-rpath,${CMAKE_BINARY_DIR}/lib \
+                -Wl,-rpath,${CMAKE_CURRENT_BINARY_DIR}/lib"
+        )
+    target_include_directories(${test_name} PUBLIC
+                               ${include_list}
+        )
+
+    target_link_directories(${test_name} PUBLIC
+                            ${CMAKE_CURRENT_BINARY_DIR}
+        )
+
+    # link all libraries sent through parameters
+    foreach(link IN LISTS link_list)
+        target_link_libraries(${test_name} ${link})
+    endforeach()
+
+    # add dependency to all the dep_list parameter
+    foreach(dependency IN LISTS dep_list)
+        add_dependencies(${test_name} ${dependency})
+        target_link_libraries(${test_name} ${dependency})
+    endforeach()
+    target_link_libraries(${test_name} -lgcov unity)
+    target_link_directories(${test_name}  PUBLIC
+                            ${CMAKE_CURRENT_BINARY_DIR}/lib
+            )
+    add_test(NAME ${test_name}
+             COMMAND ${CMAKE_BINARY_DIR}/bin/tests/${test_name}
+             WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            )
+endfunction()
+
+function(create_real_library target
+                             src_file
+                             real_include_list)
+    add_library(${target} STATIC
+            ${src_file}
+        )
+    target_include_directories(${target} PUBLIC
+            ${real_include_list}
+        )
+    set_target_properties(${target} PROPERTIES
+            COMPILE_FLAGS "-Wextra -Wpedantic \
+                -fprofile-arcs -ftest-coverage -fprofile-generate \
+                -Wno-unused-but-set-variable"
+            LINK_FLAGS "-fprofile-arcs -ftest-coverage \
+                -fprofile-generate "
+            ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib
+        )
+endfunction()

--- a/tools/unity/project.yml
+++ b/tools/unity/project.yml
@@ -1,0 +1,12 @@
+:unity:
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: TRUE
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+  :treat_externs: :exclude
+  :weak: __attribute__((weak))
+  :treat_externs: :include


### PR DESCRIPTION
This follows changes from [https://github.com/FreeRTOS/coreJSON/pull/40](https://github.com/FreeRTOS/coreJSON/pull/40):

The unit tests in the Jobs library has no need for mocks. The CMake files for the unit tests used to reference the Unity submodule in the CMock submodule. Now, the unit test build only references files from the newly created Unity submodule while the CMock submodule is deleted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
