### PR TITLE
Doxygen: Add constants page, data types page, configurations page, and function page.

### DIFF
--- a/docs/doxygen/config.doxyfile
+++ b/docs/doxygen/config.doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "jobs"
+PROJECT_NAME           = "AWS IoT Jobs"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -58,7 +58,7 @@ Unit tests and [CBMC](https://www.cprover.org/cbmc/) proofs are written to cover
 <!-- @par configpagestyle allows the @section titles to be styled according to style.css -->
 @par configpagestyle
 
-Some configuration settings are C pre-processor constants they are set using a compiler option such as -D in gcc.
+These configuration settings are C pre-processor constants they are set using a compiler option such as -D in gcc.
 
 @section THINGNAME_MAX_LENGTH
 @copydoc THINGNAME_MAX_LENGTH

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -51,3 +51,63 @@ All functions are written to have minimal complexity.
 Unit tests and [CBMC](https://www.cprover.org/cbmc/) proofs are written to cover every path of execution and achieve 100% branch coverage.
 </p>
 */
+
+/**
+@page jobs_config Configurations
+@brief Configurations of the Jobs Library.
+<!-- @par configpagestyle allows the @section titles to be styled according to style.css -->
+@par configpagestyle
+
+Some configuration settings are C pre-processor constants they are set using a compiler option such as -D in gcc.
+
+@section THINGNAME_MAX_LENGTH
+@copydoc THINGNAME_MAX_LENGTH
+
+@section JOBID_MAX_LENGTH
+@copydoc JOBID_MAX_LENGTH
+*/
+
+/**
+@page jobs_functions Functions
+@brief Primary functions of the Jobs library:<br><br>
+@subpage jobs_gettopic_function <br>
+@subpage jobs_matchtopic_function <br>
+@subpage jobs_getpending_function <br>
+@subpage jobs_startnext_function <br>
+@subpage jobs_describe_function <br>
+@subpage jobs_startnext_function <br>
+
+@page jobs_gettopic_function Jobs_GetTopic
+@snippet jobs.h declare_jobs_gettopic
+@copydoc Jobs_GetTopic
+
+@page jobs_matchtopic_function Jobs_MatchTopic
+@snippet jobs.h declare_jobs_matchtopic
+@copydoc Jobs_MatchTopic
+
+@page jobs_getpending_function Jobs_GetPending
+@snippet jobs.h declare_jobs_getpending
+@copydoc Jobs_GetPending
+
+@page jobs_startnext_function Jobs_StartNext
+@snippet jobs.h declare_jobs_startnext
+@copydoc Jobs_StartNext
+
+@page jobs_describe_function Jobs_Describe
+@snippet jobs.h declare_jobs_describe
+@copydoc Jobs_Describe
+
+@page jobs_update_function Jobs_Update
+@snippet jobs.h declare_jobs_update
+@copydoc Jobs_Update
+*/
+
+/**
+@defgroup jobs_enum_types Enumerated Types
+@brief Enumerated types of the Jobs library
+*/
+
+/**
+@defgroup jobs_constants Constants
+@brief Constants defined in the Jobs library
+*/

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -5,6 +5,7 @@ apis
 ascii
 aws
 blength
+br
 buf
 buffera
 bufferb
@@ -24,6 +25,7 @@ html
 https
 ifndef
 inc
+ingroup
 iot
 jobid
 jobidlength
@@ -48,6 +50,7 @@ outjobid
 outjobidlength
 outlength
 param
+ref
 spdx
 startnextpendingjobexecution
 stderr

--- a/source/include/jobs.h
+++ b/source/include/jobs.h
@@ -34,11 +34,13 @@
 #include <stdint.h>
 
 /**
+ * @ingroup jobs_constants
  * @brief Maximum length of a thing name for the AWS IoT Jobs Service.
  */
 #define JOBS_THINGNAME_MAX_LENGTH    128U      /* per AWS IoT API Reference */
 
 /**
+ * @ingroup jobs_constants
  * @brief Maximum length of a job ID for the AWS IoT Jobs Service.
  */
 #define JOBS_JOBID_MAX_LENGTH        64U       /* per AWS IoT API Reference */
@@ -47,6 +49,8 @@
 
 /**
  * @brief User defined maximum length of a thing name for the application.
+ *
+ * <br><b>Default value</b>: @ref JOBS_THINGNAME_MAX_LENGTH
  */
     #define THINGNAME_MAX_LENGTH    JOBS_THINGNAME_MAX_LENGTH
 #endif
@@ -55,6 +59,8 @@
 
 /**
  * @brief User defined maximum length of a job ID for the application.
+ *
+ * <br><b>Default value</b>: @ref JOBS_JOBID_MAX_LENGTH
  */
     #define JOBID_MAX_LENGTH    JOBS_JOBID_MAX_LENGTH
 #endif
@@ -105,6 +111,7 @@
 /** @endcond */
 
 /**
+ * @ingroup jobs_constants
  * @brief The size needed to hold the longest topic for a given thing name length.
  * @note This includes space for a terminating NUL character.
  */
@@ -114,6 +121,7 @@
       JOBS_API_SUCCESS_LENGTH + 1U )
 
 /**
+ * @ingroup jobs_enum_types
  * @brief Return codes from jobs functions.
  */
 typedef enum
@@ -126,6 +134,7 @@ typedef enum
 } JobsStatus_t;
 
 /**
+ * @ingroup jobs_enum_types
  * @brief Topic values for subscription requests.
  *
  * @note The enum values for valid topics must be contiguous,
@@ -177,12 +186,14 @@ typedef enum
  *
  * @note The thingName parameter does not need a NULL terminator.
  */
+/* @[declare_jobs_gettopic] */
 JobsStatus_t Jobs_GetTopic( char * buffer,
                             size_t length,
                             const char * thingName,
                             uint16_t thingNameLength,
                             JobsTopic_t api,
                             size_t * outLength );
+/* @[declare_jobs_gettopic] */
 
 /**
  * @brief Output a topic value if a Jobs API topic string is present.
@@ -208,6 +219,7 @@ JobsStatus_t Jobs_GetTopic( char * buffer,
  * NULL and 0 are output when no jobID is present.
  * The parameters jobId and jobIdLength may be NULL.
  */
+/* @[declare_jobs_matchtopic] */
 JobsStatus_t Jobs_MatchTopic( char * topic,
                               size_t length,
                               const char * thingName,
@@ -215,6 +227,7 @@ JobsStatus_t Jobs_MatchTopic( char * topic,
                               JobsTopic_t * outApi,
                               char ** outJobId,
                               uint16_t * outJobIdLength );
+/* @[declare_jobs_matchtopic] */
 
 /**
  * @brief Populate a topic string for a GetPendingJobExecutions request.
@@ -235,11 +248,13 @@ JobsStatus_t Jobs_MatchTopic( char * topic,
  *
  * @note The thingName parameter does not need a NULL terminator.
  */
+/* @[declare_jobs_getpending] */
 JobsStatus_t Jobs_GetPending( char * buffer,
                               size_t length,
                               const char * thingName,
                               uint16_t thingNameLength,
                               size_t * outLength );
+/* @[declare_jobs_getpending] */
 
 /**
  * @brief Populate a topic string for a StartNextPendingJobExecution request.
@@ -260,11 +275,13 @@ JobsStatus_t Jobs_GetPending( char * buffer,
  *
  * @note The thingName parameter does not need a NULL terminator.
  */
+/* @[declare_jobs_startnext] */
 JobsStatus_t Jobs_StartNext( char * buffer,
                              size_t length,
                              const char * thingName,
                              uint16_t thingNameLength,
                              size_t * outLength );
+/* @[declare_jobs_startnext] */
 
 /**
  * @brief Populate a topic string for a DescribeJobExecution request.
@@ -287,6 +304,7 @@ JobsStatus_t Jobs_StartNext( char * buffer,
  *
  * @note The thingName and jobId parameters do not need a NULL terminator.
  */
+/* @[declare_jobs_describe] */
 JobsStatus_t Jobs_Describe( char * buffer,
                             size_t length,
                             const char * thingName,
@@ -294,6 +312,7 @@ JobsStatus_t Jobs_Describe( char * buffer,
                             const char * jobId,
                             uint16_t jobIdLength,
                             size_t * outLength );
+/* @[declare_jobs_describe] */
 
 /**
  * @brief Populate a topic string for an UpdateJobExecution request.
@@ -316,6 +335,7 @@ JobsStatus_t Jobs_Describe( char * buffer,
  *
  * @note The thingName and jobId parameters do not need a NULL terminator.
  */
+/* @[declare_jobs_update] */
 JobsStatus_t Jobs_Update( char * buffer,
                           size_t length,
                           const char * thingName,
@@ -323,5 +343,6 @@ JobsStatus_t Jobs_Update( char * buffer,
                           const char * jobId,
                           uint16_t jobIdLength,
                           size_t * outLength );
+/* @[declare_jobs_update] */
 
 #endif /* ifndef JOBS_H_ */


### PR DESCRIPTION
Out of scope: Adding a jobs_config_defaults.h or a jobs_config.h to the library. That is a separate endeavor.

This PR adds a few pages to the doxygen for consistency and to copy the user compile time configurations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
