### PR TITLE
Fix Capitalizing the T in IoT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AWS IoT Jobs is a service that notifies one or more connected devices of a
 pending “Job”.  A Job can be used to manage your fleet of devices, update
 firmware and security certificates on your devices, or perform administrative
 tasks such as restarting devices and performing diagnostics. For documentation
-of the service, please see the [AWS Iot Developer
+of the service, please see the [AWS IoT Developer
 Guide](https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html).
 Interactions with the Jobs service use MQTT, a lightweight
 publish-subscribe protocol.  This library provides a convenience API to

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -5,7 +5,7 @@
 
 <p>
 AWS IoT jobs can be used to define a set of remote operations that are sent to and executed on one or more devices connected to AWS IoT.
-For documentation of the service, please see the [AWS Iot Developer Guide](https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html).
+For documentation of the service, please see the [AWS IoT Developer Guide](https://docs.aws.amazon.com/iot/latest/developerguide/iot-jobs.html).
 Interactions with the jobs service use MQTT, a lightweight publish-subscribe protocol.
 This library provides a convenience API to compose and recognize the MQTT topic strings used by the jobs service.
 The library is written in C and designed to be compliant with ISO C90 and MISRA C:2012.


### PR DESCRIPTION
Capitalize the T in IoT in places missed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
