### PR TITLE
Add CRLF check to formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,13 @@ jobs:
           git ls-files | while read f; do [[ -f $f ]] && grep -H '[[:blank:]]$' $f && let found++; done
           (( found > 0 )) && echo 'Files have trailing whitespace.'
           exit $found
+      - name: Check for CRLF
+        run: |
+          set +e
+          find . -path ./.git -prune -o -exec file {} + |  grep "CRLF"
+          if [ "$?" = "0" ]; then
+            echo "Files have CRLF line endings."
+            exit 1
+          else
+            exit 0
+          fi


### PR DESCRIPTION
Have CI check for CRLF line endings to make sure line endings remain consistent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
