### PR TITLE
Update memory estimates table

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -29,6 +29,11 @@ It has proofs showing safe memory use and no heap allocation, making it suitable
         <td><center>1.7K</center></td>
         <td><center>1.4K</center></td>
     </tr>
+    <tr>
+        <td><b>Total estimate</b></td>
+        <td><center>1.7K</center></td>
+        <td><center>1.4K</center></td>
+    </tr>
 </table>
  */
 

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -31,8 +31,8 @@ It has proofs showing safe memory use and no heap allocation, making it suitable
     </tr>
     <tr>
         <td><b>Total estimate</b></td>
-        <td><center>1.7K</center></td>
-        <td><center>1.4K</center></td>
+        <td><center><b>1.7K</b></center></td>
+        <td><center><b>1.4K</b></center></td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -21,15 +21,13 @@ It has proofs showing safe memory use and no heap allocation, making it suitable
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>No Optimization (asserts enabled)</b></td>
         <td><b>With -O1 Optimization (asserts disabled)</b></td>
         <td><b>With -Os Optimization (asserts disabled)</b></td>
     </tr>
     <tr>
         <td>jobs.c</td>
-        <td>4.8K</td>
-        <td>3.1K</td>
-        <td>2.8K</td>
+        <td>1.7K</td>
+        <td>1.4K</td>
     </tr>
 </table>
  */

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -17,17 +17,17 @@ It has proofs showing safe memory use and no heap allocation, making it suitable
 
 <table>
     <tr>
-        <td colspan="4"><center><b>Code size of Jobs library files (sizes generated with [GCC for ARM Cortex-M toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads/9-2020-q2-update))</b></center></td>
+        <td colspan="3"><center><b>Code size of AWS IoT Jobs (example generated with GCC for ARM Cortex-M)</b></center></td>
     </tr>
     <tr>
         <td><b>File</b></td>
-        <td><b>With -O1 Optimization (asserts disabled)</b></td>
-        <td><b>With -Os Optimization (asserts disabled)</b></td>
+        <td><center><b>With -O1 Optimization</b></center></td>
+        <td><center><b>With -Os Optimization</b></center></td>
     </tr>
     <tr>
         <td>jobs.c</td>
-        <td>1.7K</td>
-        <td>1.4K</td>
+        <td><center>1.7K</center></td>
+        <td><center>1.4K</center></td>
     </tr>
 </table>
  */


### PR DESCRIPTION
Updates the memory estimates doxygen table to be in line with numbers on Freertos.org

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
