### PR TITLE
matchIdApi was not considering $next as a valid ID. Added a check.

### DIFF
--- a/source/jobs.c
+++ b/source/jobs.c
@@ -427,8 +427,8 @@ static JobsStatus_t matchIdApi( char * topic,
     p = &p[ jobIdLength + 1U ];
     length = length - jobIdLength - 1U;
 
-    if ( ( isNextJobId( jobId, jobIdLength ) == true ) ||
-          ( isValidJobId( jobId, jobIdLength ) == true ) )
+    if( ( isNextJobId( jobId, jobIdLength ) == true ) ||
+        ( isValidJobId( jobId, jobIdLength ) == true ) )
     {
         JobsTopic_t api;
 

--- a/source/jobs.c
+++ b/source/jobs.c
@@ -359,6 +359,30 @@ static JobsStatus_t strnnEq( const char * a,
 }
 
 /**
+ * @brief Predicate returns true for a match to JOBS_API_JOBID_NEXT
+ *
+ * @param[in] jobId  character sequence to check
+ * @param[in] jobIdLength  length of the character sequence
+ *
+ * @return true if the job ID matches;
+ * false otherwise
+ */
+static bool_ isNextJobId( const char * jobId,
+                          uint16_t jobIdLength )
+{
+    bool_ ret = false;
+
+    if( ( jobId != NULL ) &&
+        ( strnnEq( JOBS_API_JOBID_NEXT, JOBS_API_JOBID_NEXT_LENGTH, jobId, jobIdLength ) == JobsSuccess ) )
+    {
+        ret = true;
+    }
+
+    return ret;
+}
+
+
+/**
  * @brief Parse a job ID and search for the API portion of a topic string in a table.
  *
  * @param[in] topic  The topic string to check.
@@ -403,7 +427,8 @@ static JobsStatus_t matchIdApi( char * topic,
     p = &p[ jobIdLength + 1U ];
     length = length - jobIdLength - 1U;
 
-    if( isValidJobId( jobId, jobIdLength ) == true )
+    if ( ( isNextJobId( jobId, jobIdLength ) == true ) ||
+          ( isValidJobId( jobId, jobIdLength ) == true ) )
     {
         JobsTopic_t api;
 
@@ -600,28 +625,6 @@ JobsStatus_t Jobs_StartNext( char * buffer,
     return ret;
 }
 
-/**
- * @brief Predicate returns true for a match to JOBS_API_JOBID_NEXT
- *
- * @param[in] jobId  character sequence to check
- * @param[in] jobIdLength  length of the character sequence
- *
- * @return true if the job ID matches;
- * false otherwise
- */
-static bool_ isNextJobId( const char * jobId,
-                          uint16_t jobIdLength )
-{
-    bool_ ret = false;
-
-    if( ( jobId != NULL ) &&
-        ( strnnEq( JOBS_API_JOBID_NEXT, JOBS_API_JOBID_NEXT_LENGTH, jobId, jobIdLength ) == JobsSuccess ) )
-    {
-        ret = true;
-    }
-
-    return ret;
-}
 
 /**
  * See jobs.h for docs.

--- a/test/unit-test/jobs_utest.c
+++ b/test/unit-test/jobs_utest.c
@@ -435,6 +435,16 @@ void test_Jobs_match_topic( void )
     TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, &outJobId, &outJobIdLength ) );
     TEST_JOBID();
 
+    setVars( JobsDescribeSuccess, PREFIX "$next/get/accepted", "$next" );
+    TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, NULL, NULL ) );
+    TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, &outJobId, &outJobIdLength ) );
+    TEST_JOBID();
+
+    setVars( JobsDescribeFailed, PREFIX "$next/get/rejected", "$next" );
+    TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, NULL, NULL ) );
+    TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, &outJobId, &outJobIdLength ) );
+    TEST_JOBID();
+
     setVars( JobsUpdateSuccess, PREFIX "12345/update/accepted", "12345" );
     TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, NULL, NULL ) );
     TEST_SUCCESS( Jobs_MatchTopic( topic, topicLength, name_, nameLength_, &outApi, &outJobId, &outJobIdLength ) );


### PR DESCRIPTION
Moved isNextJobId to above the matchIdApi function since there's no forward declaration.

*Issue #, if available:* None

*Description of changes:*
The current matchIdApi was only checking for valid characters. Added a check to see if $next was being returned in the Id.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
