### PR TITLE
Add note in doxygen about co-existence of OTA agent and Jobs library

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -12,16 +12,16 @@ The library is written in C and designed to be compliant with ISO C90 and MISRA 
 It has proofs showing safe memory use and no heap allocation, making it suitable for IoT microcontrollers, but also fully portable to other platforms.
 </p>
 
-> **NOTE**  
-> If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.  
-> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
-
-
 @section jobs_memory_requirements Memory Requirements
 @brief Memory requirements of the jobs library.
 
 @include{doc} size_table.html
  */
+
+
+> **NOTE**  
+> If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.  
+> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
 
 /**
 @page jobs_features Features

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -13,8 +13,9 @@ It has proofs showing safe memory use and no heap allocation, making it suitable
 </p>
 
 > **NOTE**:
-> If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.
-> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
+> If your application uses both AWS IoT Jobs library and [OTA library](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.
+> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs topics between multiple tasks/threads.
+> However, if you choose to use different tasks/threads for calling these libraries, please be aware that the OTA library will subscribe and configurably, unsubscribe from AWS IoT Jobs topics, and also attempt to send status updates for incoming non-OTA jobs, if your application configures the OTA library to handle custom jobs.
 
 @section jobs_memory_requirements Memory Requirements
 @brief Memory requirements of the jobs library.

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -12,16 +12,15 @@ The library is written in C and designed to be compliant with ISO C90 and MISRA 
 It has proofs showing safe memory use and no heap allocation, making it suitable for IoT microcontrollers, but also fully portable to other platforms.
 </p>
 
+> **NOTE**  
+> If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.
+> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
+
 @section jobs_memory_requirements Memory Requirements
 @brief Memory requirements of the jobs library.
 
 @include{doc} size_table.html
  */
-
-
-> **NOTE**  
-> If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.  
-> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
 
 /**
 @page jobs_features Features

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -12,6 +12,11 @@ The library is written in C and designed to be compliant with ISO C90 and MISRA 
 It has proofs showing safe memory use and no heap allocation, making it suitable for IoT microcontrollers, but also fully portable to other platforms.
 </p>
 
+> **NOTE**  
+> If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.  
+> As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
+
+
 @section jobs_memory_requirements Memory Requirements
 @brief Memory requirements of the jobs library.
 

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -12,7 +12,7 @@ The library is written in C and designed to be compliant with ISO C90 and MISRA 
 It has proofs showing safe memory use and no heap allocation, making it suitable for IoT microcontrollers, but also fully portable to other platforms.
 </p>
 
-> **NOTE**  
+> **NOTE**:
 > If your application uses AWS IoT Jobs library and [OTA agent](https://github.com/aws/ota-for-aws-iot-embedded-sdk) to communicate with AWS IoT through a shared MQTT connection, we suggest that you keep the application logic that uses these libraries within a single task/thread.
 > As the OTA agent also makes calls to the AWS IoT Jobs service, keeping the use of libraries within the same thread context will avoid complexity of synchronizing communication with AWS IoT Jobs between multiple tasks/threads.
 

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -14,6 +14,7 @@ colspan
 com
 cond
 configpagestyle
+configurably
 copydoc
 coverity
 cprover

--- a/lexicon.txt
+++ b/lexicon.txt
@@ -30,6 +30,7 @@ enums
 fd
 gcc
 getpendingjobexecutions
+github
 html
 https
 ifndef
@@ -72,6 +73,7 @@ noninfringement
 nul
 org
 os
+ota
 outapi
 outjobid
 outjobidlength


### PR DESCRIPTION
If the customer application chooses to use the Jobs and OTA agent libraries, then both libraries should be used in the same application task to simplicity of program logic; otherwise, different tasks communication with AWS IoT Jobs service will need to synchronize with each other. This PR adds a suggestive note about the same to the library API reference documentation.