### PR TITLE
Update a 2.5 MISRA rule in the MISRA.md file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Other Updates:
 - [#37](https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/pull/37) Add code examples in documentation of API functions.
+- [#43](https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/pull/37) Add MISRA rule 2.5 in the 'Flagged by Coverity' section of MISRA.md file.
 
 ## v1.0.0 (November 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Other Updates:
 - [#37](https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/pull/37) Add code examples in documentation of API functions.
-- [#43](https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/pull/37) Add MISRA rule 2.5 in the 'Flagged by Coverity' section of MISRA.md file.
+- [#43](https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/pull/37) Add MISRA rule 2.5 in list of ignored violations in MISRA.md file.
 
 ## v1.0.0 (November 2020)
 

--- a/MISRA.md
+++ b/MISRA.md
@@ -15,6 +15,7 @@ Deviations from the MISRA standard are listed below:
 ### Flagged by Coverity
 | Deviation | Category | Justification |
 | :-: | :-: | :-: |
+| Rule 2.5 | Advisory | A macro is not used by the library; however, it exists to be used by an application. |
 | Rule 8.7 | Advisory | API functions are not used by the library; however, they must be externally visible in order to be used by an application. |
 
 ### Suppressed with Coverity Comments


### PR DESCRIPTION
*Description of changes:*
Update a 2.5 MISRA rule in the MISRA.md file. This rule is flagged by Coverity as some MACROs are not used in the library. These MACROs are meant to be used by the application.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
