### PR TITLE
Fix issue in doxygen rendering of Jobs

### DIFF
--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -64,7 +64,6 @@ These configuration settings are C pre-processor constants they are set using a 
 @subpage jobs_getpending_function <br>
 @subpage jobs_startnext_function <br>
 @subpage jobs_describe_function <br>
-@subpage jobs_startnext_function <br>
 @subpage jobs_update_function <br>
 
 @page jobs_gettopic_function Jobs_GetTopic

--- a/docs/doxygen/pages.dox
+++ b/docs/doxygen/pages.dox
@@ -65,6 +65,7 @@ These configuration settings are C pre-processor constants they are set using a 
 @subpage jobs_startnext_function <br>
 @subpage jobs_describe_function <br>
 @subpage jobs_startnext_function <br>
+@subpage jobs_update_function <br>
 
 @page jobs_gettopic_function Jobs_GetTopic
 @snippet jobs.h declare_jobs_gettopic

--- a/source/include/jobs.h
+++ b/source/include/jobs.h
@@ -257,6 +257,8 @@ typedef enum
     JobsMaxTopic
 } JobsTopic_t;
 
+/*-----------------------------------------------------------*/
+
 /**
  * @brief Populate a topic string for a subscription request.
  *


### PR DESCRIPTION
The `Jobs_Update` function appears as a separate item on the left-panel of the landing page for Jobs library doxygen. Here are the before and after images.

**Before**:
![image](https://user-images.githubusercontent.com/5158611/109707864-8a6d8c00-7b4f-11eb-8c06-1dba9fa303ac.png)

**After**:
![image](https://user-images.githubusercontent.com/5158611/109707780-6c079080-7b4f-11eb-853b-e49ab9b06ff9.png)
