### PR TITLE
Move declaration of temporary variables after length check

### DIFF
--- a/source/jobs.c
+++ b/source/jobs.c
@@ -521,23 +521,25 @@ JobsStatus_t Jobs_MatchTopic( char * topic,
 
     if( ( topic != NULL ) && ( outApi != NULL ) && checkThingParams() && ( length > 0U ) )
     {
-        char * prefix = topic;
-        char * name = &prefix[ JOBS_API_PREFIX_LENGTH ];
-        char * bridge = &name[ thingNameLength ];
-
         ret = JobsNoMatch;
 
-        /* check the shortest match first */
         if( ( length > JOBS_API_COMMON_LENGTH( thingNameLength ) ) &&
-            ( length < JOBS_API_MAX_LENGTH( thingNameLength ) ) &&
-            ( strnEq( bridge, JOBS_API_BRIDGE, JOBS_API_BRIDGE_LENGTH ) == JobsSuccess ) &&
-            ( strnEq( prefix, JOBS_API_PREFIX, JOBS_API_PREFIX_LENGTH ) == JobsSuccess ) &&
-            ( strnEq( name, thingName, thingNameLength ) == JobsSuccess ) )
+            ( length < JOBS_API_MAX_LENGTH( thingNameLength ) ) )
         {
-            char * tail = &bridge[ JOBS_API_BRIDGE_LENGTH ];
-            size_t tailLength = length - JOBS_API_COMMON_LENGTH( thingNameLength );
+            char * prefix = topic;
+            char * name = &prefix[ JOBS_API_PREFIX_LENGTH ];
+            char * bridge = &name[ thingNameLength ];
 
-            ret = matchApi( tail, tailLength, &api, &jobId, &jobIdLength );
+            /* check the shortest match first */
+            if( ( strnEq( bridge, JOBS_API_BRIDGE, JOBS_API_BRIDGE_LENGTH ) == JobsSuccess ) &&
+                ( strnEq( prefix, JOBS_API_PREFIX, JOBS_API_PREFIX_LENGTH ) == JobsSuccess ) &&
+                ( strnEq( name, thingName, thingNameLength ) == JobsSuccess ) )
+            {
+                char * tail = &bridge[ JOBS_API_BRIDGE_LENGTH ];
+                size_t tailLength = length - JOBS_API_COMMON_LENGTH( thingNameLength );
+
+                ret = matchApi( tail, tailLength, &api, &jobId, &jobIdLength );
+            }
         }
     }
 

--- a/test/cbmc/proofs/Makefile
+++ b/test/cbmc/proofs/Makefile
@@ -16,7 +16,7 @@ all: precheck clean
 	for d in $(DIRS); do \
 		echo -n $$d; \
 		time make -C $$d 2>&1 | mawk -W interactive 'NR % 30 == 0 {printf "."}'; echo; \
-		w3m -cols 120 -dump $$d/html/index.html | sed 's/^/        /'; \
+		w3m -cols 120 -dump $$d/html/html/index.html | sed 's/^/        /'; \
 	done
 
 clean:


### PR DESCRIPTION
Before, some temporary variables were declared to point to various positions in a string.  These variables were safely accessed after a length check passed.  Newer versions of CBMC flag this as a possible issue.  This PR moves the declarations after the length check and the proof runs cleanly again. 