### PR TITLE
Update broken MISRA link

### DIFF
--- a/MISRA.md
+++ b/MISRA.md
@@ -1,7 +1,7 @@
 
 # MISRA Compliance
 
-The jobs library files conform to the [MISRA C:2012](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx)
+The jobs library files conform to the [MISRA C:2012](https://www.misra.org.uk)
 guidelines, with some noted exceptions. Compliance is checked with Coverity static analysis.
 Deviations from the MISRA standard are listed below:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ including verification that no function has a [GNU Complexity
 ](https://www.gnu.org/software/complexity/manual/complexity.html)
 score over 8, and checks against deviations
 from mandatory rules in the [MISRA coding standard
-](https://www.misra.org.uk/MISRAHome/MISRAC2012/tabid/196/Default.aspx).
+](https://www.misra.org.uk).
 Deviations from the MISRA C:2012 guidelines are documented under [MISRA
 Deviations](MISRA.md). This library has also undergone both static code
 analysis from [Coverity](https://scan.coverity.com/), and validation of


### PR DESCRIPTION
Because the MISRA website was updated, an older link is no longer valid. Update the link so that it just points to the domain to avoid this from happening again.