### PR TITLE
Fix: ExpectedVersion is optional in update msg

### DIFF
--- a/source/include/jobs.h
+++ b/source/include/jobs.h
@@ -839,8 +839,8 @@ JobsStatus_t Jobs_Update( char * buffer,
  * @brief Populate a message string for an UpdateJobExecution request.
  *
  * @param status Current status of the job
- * @param expectedVersion The version that is expected
- * @param expectedVersionLength The length of the expectedVersion string
+ * @param expectedVersion The version that is expected, NULL if no version is expected
+ * @param expectedVersionLength The length of the expectedVersion string, 0U if no version is expected
  * @param buffer The buffer to be written to
  * @param bufferSize the size of the buffer
  *
@@ -853,6 +853,7 @@ JobsStatus_t Jobs_Update( char * buffer,
  * // The Following Example shows usage of the Jobs_UpdateMsg API to
  * // generate a message string for the UpdateJobExecution API
  * // of the AWS IoT Jobs Service
+ *
  * const char * expectedVersion = "2";
  * size_t expectedVersionLength = ( sizeof(expectedVersion ) - 1U );
  * JobCurrentStatus_t status = Succeeded;

--- a/source/jobs.c
+++ b/source/jobs.c
@@ -840,15 +840,30 @@ size_t Jobs_UpdateMsg( JobCurrentStatus_t status,
     assert( ( ( size_t ) status ) < ARRAY_LENGTH( jobStatusString ) );
 
     size_t start = 0U;
+    size_t minimumBufferSize = JOBS_API_STATUS_LENGTH + jobStatusStringLengths[ status ] + CONST_STRLEN( "\"}" );
 
-    if( ( expectedVersion != NULL ) && ( expectedVersionLength > 0U ) && ( bufferSize >=
-                                                                           ( 34U + expectedVersionLength + jobStatusStringLengths[ status ] ) ) &&
-        ( jobStatusString[ status ] != NULL ) )
+    if( ( expectedVersion != NULL ) && ( expectedVersionLength > 0U ) )
+    {
+        minimumBufferSize += JOBS_API_EXPECTED_VERSION_LENGTH + expectedVersionLength;
+    }
+
+    bool writeFailed = bufferSize < minimumBufferSize;
+
+    if( !writeFailed && ( jobStatusString[ status ] != NULL ) )
     {
         ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_STATUS, JOBS_API_STATUS_LENGTH );
         ( void ) strnAppend( buffer, &start, bufferSize, jobStatusString[ status ], jobStatusStringLengths[ status ] );
+    }
+
+    /* This is an optional field so do not fail if expected version is missing */
+    if( !writeFailed && ( expectedVersion != NULL ) && ( expectedVersionLength > 0U ) )
+    {
         ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_EXPECTED_VERSION, JOBS_API_EXPECTED_VERSION_LENGTH );
         ( void ) strnAppend( buffer, &start, bufferSize, expectedVersion, expectedVersionLength );
+    }
+
+    if( !writeFailed )
+    {
         ( void ) strnAppend( buffer, &start, bufferSize, "\"}", ( CONST_STRLEN( "\"}" ) ) );
     }
 

--- a/test/unit-test/jobs_utest.c
+++ b/test/unit-test/jobs_utest.c
@@ -883,7 +883,7 @@ void test_getUpdateJobExecutionMsg_hasNullExpectedVersion( void )
 
     size_t result = Jobs_UpdateMsg( status, NULL, 1U, buffer, TOPIC_BUFFER_SIZE );
 
-    TEST_ASSERT_EQUAL( 0U, result );
+    TEST_ASSERT_EQUAL( 19U, result );
 }
 
 void test_getUpdateJobExecutionMsg_hasZeroLengthExpectedVersion( void )
@@ -894,22 +894,32 @@ void test_getUpdateJobExecutionMsg_hasZeroLengthExpectedVersion( void )
 
     size_t result = Jobs_UpdateMsg( status, version, 0U, buffer, TOPIC_BUFFER_SIZE );
 
+    TEST_ASSERT_EQUAL( 19U, result );
+}
+
+void test_getUpdateJobExecutionMsg_hasTooSmallBufferSizeForRequiredParameters( void )
+{
+    JobCurrentStatus_t status = Queued;
+    char buffer[ 2 ] = { 0 };
+
+    size_t result = Jobs_UpdateMsg( status, NULL, 0U, buffer, 1 );
+
     TEST_ASSERT_EQUAL( 0U, result );
 }
 
-void test_getUpdateJobExecutionMsg_hasTooSmallBufferSize( void )
+void test_getUpdateJobExecutionMsg_hasTooSmallBufferSizeForAllParameters( void )
 {
     char * version = "1.0.1";
     size_t versionLength = strlen( version );
     JobCurrentStatus_t status = Queued;
-    char buffer[ 2 ] = { 0 };
+    char buffer[ 25 ] = { 0 };
 
     size_t result = Jobs_UpdateMsg( status, version, versionLength, buffer, 1 );
 
     TEST_ASSERT_EQUAL( 0U, result );
 }
 
-void test_getUpdateJobExecutionMsg_hasValidParameters( void )
+void test_getUpdateJobExecutionMsg_hasAllValidParameters( void )
 {
     char * version = "1.0.1";
     size_t versionLength = strlen( version );
@@ -919,4 +929,14 @@ void test_getUpdateJobExecutionMsg_hasValidParameters( void )
     size_t result = Jobs_UpdateMsg( status, version, versionLength, buffer, TOPIC_BUFFER_SIZE );
 
     TEST_ASSERT_EQUAL( 45U, result );
+}
+
+void test_getUpdateJobExecutionMsg_hasRequiredValidParameters( void )
+{
+    JobCurrentStatus_t status = Queued;
+    char buffer[ TOPIC_BUFFER_SIZE + 1 ] = { 0 };
+
+    size_t result = Jobs_UpdateMsg( status, NULL, 0U, buffer, TOPIC_BUFFER_SIZE );
+
+    TEST_ASSERT_EQUAL( 19U, result );
 }


### PR DESCRIPTION
*Description of changes:*
Per the AWS documentation the 'ExpectedVersion'
field is optional in an update msg for a job. This changes makes the expected version field optional.

https://docs.aws.amazon.com/iot/latest/apireference/API_iot-jobs-data_UpdateJobExecution.html#iot-iot-jobs-data_UpdateJobExecution-request-status

*Issue #, if available:*
https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/issues/100


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
