### PR TITLE
Replace char pointer with char array in samples.

### DIFF
--- a/source/include/jobs.h
+++ b/source/include/jobs.h
@@ -681,7 +681,7 @@ JobsStatus_t Jobs_StartNext( char * buffer,
  * // The Following Example shows usage of the Jobs_StartNextMsg API
  * // to generate a message string for a StartNextPendingJobExecution request.
  *
- * const char * clientToken = "test";
+ * const char clientToken[] = "test";
  * size_t clientTokenLength = ( sizeof( clientToken ) - 1U );
  * char messageBuffer[ START_JOB_MSG_LENGTH ] = {0};
  * size_t messageLength = 0U;
@@ -881,8 +881,8 @@ JobsStatus_t Jobs_Update( char * buffer,
  * // generate a message string for the UpdateJobExecution API
  * // of the AWS IoT Jobs Service.
  *
- * const char * expectedVersion = "2";
- * const chat * statusDetails = "{\"key\":\"value\"}";
+ * const char expectedVersion[] = "2";
+ * const char statusDetails[] = "{\"key\":\"value\"}";
  * char messageBuffer[ UPDATE_JOB_MSG_LENGTH ]  = {0};
  * size_t messageLength = 0U;
  *


### PR DESCRIPTION
*Issue #, if available:*
#107 

*Description of changes:*
The sample codes for `Jobs_StartNextMsg()` and `Jobs_UpdateMsg()` in jobs.h is wrong. Replace the char pointer with char array to calculate the length correctly.

---
For example, before changing:
```
const char * statusDetails = "{\"key\":\"value\"}";
/* ... */
request.statusDetailsLength = ( sizeof( statusDetails ) - 1U );
```
In this case, `sizeof( statusDetails )` returns the size of **pointer**, which is 4 or 8, instead of the length.

---
After changing:
```
const char statusDetails[] = "{\"key\":\"value\"}";
/* ... */
request.statusDetailsLength = ( sizeof( statusDetails ) - 1U );
```
In this case, `sizeof( statusDetails )` returns the size of **array**, which is 15.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
