### PR TITLE
Fix Jobs_UpdateMsg to generate valid JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ doxygen docs/doxygen/config.doxyfile
 
 ### Steps to build Unit Tests
 
-1. Create build directory: `mkdir build && cd build`
+1. Create build directory: `mkdir build`
 
-1. Run _cmake_ while inside build directory: `cmake -S ../test`
+1. Run _cmake_ while inside build directory: `cmake -S test/ -B build/`
+
+1. Change to build directory: `cd build`
 
 1. Run this command to build the library and unit tests: `make all`
 

--- a/source/include/jobs.h
+++ b/source/include/jobs.h
@@ -150,7 +150,7 @@
 #define JOBS_API_EXPECTED_VERSION           "\",\"expectedVersion\":\""
 #define JOBS_API_EXPECTED_VERSION_LENGTH    ( sizeof( JOBS_API_EXPECTED_VERSION ) - 1U )
 
-#define JOBS_API_STATUS_DETAILS             "\",\"statusDetails\":\""
+#define JOBS_API_STATUS_DETAILS             "\",\"statusDetails\":"
 #define JOBS_API_STATUS_DETAILS_LENGTH      ( sizeof( JOBS_API_STATUS_DETAILS ) - 1U )
 
 #define JOBS_API_COMMON_LENGTH( thingNameLength ) \

--- a/source/jobs.c
+++ b/source/jobs.c
@@ -893,25 +893,26 @@ size_t Jobs_UpdateMsg( JobsUpdateRequest_t request,
     {
         ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_STATUS, JOBS_API_STATUS_LENGTH );
         ( void ) strnAppend( buffer, &start, bufferSize, jobStatusString[ request.status ], strlen( jobStatusString[ request.status ] ) );
-    }
 
-    /* This is an optional field so do not fail if expected version is missing.*/
-    if( !writeFailed && ( request.expectedVersion != NULL ) && ( request.expectedVersionLength > 0U ) )
-    {
-        ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_EXPECTED_VERSION, JOBS_API_EXPECTED_VERSION_LENGTH );
-        ( void ) strnAppend( buffer, &start, bufferSize, request.expectedVersion, request.expectedVersionLength );
-    }
+        /* This is an optional field so do not fail if expected version is missing.*/
+        if( ( request.expectedVersion != NULL ) && ( request.expectedVersionLength > 0U ) )
+        {
+            ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_EXPECTED_VERSION, JOBS_API_EXPECTED_VERSION_LENGTH );
+            ( void ) strnAppend( buffer, &start, bufferSize, request.expectedVersion, request.expectedVersionLength );
+        }
 
-    /* This is an optional field so do not fail if status details is missing.*/
-    if( !writeFailed && ( request.statusDetails != NULL ) && ( request.statusDetailsLength > 0U ) )
-    {
-        ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_STATUS_DETAILS, JOBS_API_STATUS_DETAILS_LENGTH );
-        ( void ) strnAppend( buffer, &start, bufferSize, request.statusDetails, request.statusDetailsLength );
-    }
+        /* This is an optional field so do not fail if status details is missing.*/
+        if( ( request.statusDetails != NULL ) && ( request.statusDetailsLength > 0U ) )
+        {
+            ( void ) strnAppend( buffer, &start, bufferSize, JOBS_API_STATUS_DETAILS, JOBS_API_STATUS_DETAILS_LENGTH );
+            ( void ) strnAppend( buffer, &start, bufferSize, request.statusDetails, request.statusDetailsLength );
 
-    if( !writeFailed )
-    {
-        ( void ) strnAppend( buffer, &start, bufferSize, "\"}", ( CONST_STRLEN( "\"}" ) ) );
+            ( void ) strnAppend( buffer, &start, bufferSize, "}", ( CONST_STRLEN( "}" ) ) );
+        }
+        else
+        {
+            ( void ) strnAppend( buffer, &start, bufferSize, "\"}", ( CONST_STRLEN( "\"}" ) ) );
+        }
     }
 
     return start;

--- a/test/unit-test/jobs_utest.c
+++ b/test/unit-test/jobs_utest.c
@@ -891,8 +891,8 @@ void test_getUpdateJobExecutionMsg_hasNullExpectedVersion( void )
 
     size_t result = Jobs_UpdateMsg( request, buffer, TOPIC_BUFFER_SIZE );
 
-    TEST_ASSERT_EQUAL( 54U, result );
-    TEST_ASSERT_EQUAL_STRING( "{\"status\":\"QUEUED\",\"statusDetails\":\"{\"key\": \"value\"}\"}", buffer );
+    TEST_ASSERT_EQUAL( 52U, result );
+    TEST_ASSERT_EQUAL_STRING( "{\"status\":\"QUEUED\",\"statusDetails\":{\"key\": \"value\"}}", buffer );
 }
 
 void test_getUpdateJobExecutionMsg_hasZeroLengthExpectedVersion( void )
@@ -909,8 +909,8 @@ void test_getUpdateJobExecutionMsg_hasZeroLengthExpectedVersion( void )
 
     size_t result = Jobs_UpdateMsg( request, buffer, TOPIC_BUFFER_SIZE );
 
-    TEST_ASSERT_EQUAL( 54U, result );
-    TEST_ASSERT_EQUAL_STRING( "{\"status\":\"QUEUED\",\"statusDetails\":\"{\"key\": \"value\"}\"}", buffer );
+    TEST_ASSERT_EQUAL( 52U, result );
+    TEST_ASSERT_EQUAL_STRING( "{\"status\":\"QUEUED\",\"statusDetails\":{\"key\": \"value\"}}", buffer );
 }
 
 void test_getUpdateJobExecutionMsg_hasNullStatusDetails( void )
@@ -1015,8 +1015,8 @@ void test_getUpdateJobExecutionMsg_hasAllValidParameters( void )
 
     size_t result = Jobs_UpdateMsg( request, buffer, TOPIC_BUFFER_SIZE );
 
-    TEST_ASSERT_EQUAL( 80U, result );
-    TEST_ASSERT_EQUAL_STRING( "{\"status\":\"QUEUED\",\"expectedVersion\":\"1.0.1\",\"statusDetails\":\"{\"key\": \"value\"}\"}", buffer );
+    TEST_ASSERT_EQUAL( 78U, result );
+    TEST_ASSERT_EQUAL_STRING( "{\"status\":\"QUEUED\",\"expectedVersion\":\"1.0.1\",\"statusDetails\":{\"key\": \"value\"}}", buffer );
 }
 
 void test_getUpdateJobExecutionMsg_hasRequiredValidParameters( void )


### PR DESCRIPTION
Description
------------
`Jobs_UpdateMsg` was putting double quotes around the `statusDetails` value resulting in the following invalid JSON:
```
{
  "status": "QUEUED",
  "statusDetails": "{
    "key": "value"
  }"
}
```

This change removes the unnecessary double quotes to generate a valid JSON:
```
{
  "status": "QUEUED",
  "statusDetails": {
    "key": "value"
  }
}
```

This was reported here - https://github.com/aws/Jobs-for-AWS-IoT-embedded-sdk/issues/107

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
